### PR TITLE
Fix memory leak in non _MSC_VER compiled branch

### DIFF
--- a/DAIDALUS/C++/src/Util.cpp
+++ b/DAIDALUS/C++/src/Util.cpp
@@ -431,6 +431,7 @@ double Util::turnDelta(double alpha, double beta, bool turnRight) {
 
 	 /* Execute regular expression */
 	 reti = regexec(&regex, sb.c_str(), 0, NULL, 0);
+	 regfree(&regex);
 	 return !reti;
  }
 #endif


### PR DESCRIPTION
The regex used to parse doubles when `_MSC_VER` is not set (which is really just being used to test for C++11 capabilities) is missing a `regfree()` call to free the memory allocated with `regcomp()`.